### PR TITLE
DEVELOP-1298: Rename React repo/package names

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc || test -f ./dist/index.js",
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@aha-app/aha-develop-react",
+  "name": "@aha-develop/aha-develop-react",
   "version": "1.1.0",
   "description": "Common React patterns for Aha! develop",
   "main": "dist/index.js",
-  "repository": "https://github.com/aha-develop/react",
+  "repository": "https://github.com/aha-develop/aha-develop-react",
   "author": "Aha! Develop",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
- Update the `react` repo/package name to `aha-develop/aha-develop-react`.
- Don't fail on TS errors