### PR TITLE
DEVELOP-1305-2 Add useClipboard hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,25 @@ The event defaults to "mousedown" and can be customised:
 useOutsideAlerter(popupEl, onClose, { event: "mousemove" });
 ```
 
+
+### useClipboard
+
+This is a simple clipboard helper for React components to copy text to the clipboard and show an indicator for a short time:
+
+```js
+function CopyableId({ id }) {
+  const [onCopy, copied] = useClipboard();
+
+  return <div>
+    <span>{id}</span>
+    <button onClick={() => onCopy(id)}>
+      <i className="fa-regular fa-copy"></i>
+      {copied ? "Copied" : "Copy"}
+    </button>
+  </div>
+}
+```
+
 ## Components
 
 ### EmbeddedContent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aha-develop/aha-develop-react",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Common React patterns for Aha! develop",
   "main": "dist/index.js",
   "repository": "https://github.com/aha-develop/aha-develop-react",

--- a/src/hooks/useClipboard.tsx
+++ b/src/hooks/useClipboard.tsx
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+interface UseClipboardOptions {
+  timeout?: number;
+}
+
+export const useClipboard = (options: UseClipboardOptions = {}) => {
+  const [copied, setCopied] = useState<Boolean>(false);
+
+  const onCopy = (text: string) => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), options.timeout || 1000);
+  };
+
+  return [onCopy, copied] as const;
+};


### PR DESCRIPTION
Add useClipboard hook for React. This pattern is already used by several extensions so it makes sense to share this hook.
