### PR TITLE
A-14099: Update all develop extensions to use new menu code

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/react": "^17.0.3",
-    "prettier": "^2.5.1",
+    "prettier": "^2.8.1",
     "typescript": "^4.2.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aha-app/aha-develop-react",
+  "name": "@aha-develop/aha-develop-react",
   "version": "1.3.0",
   "description": "Common React patterns for Aha! develop",
   "main": "dist/index.js",

--- a/src/components/DrawerInput.tsx
+++ b/src/components/DrawerInput.tsx
@@ -11,14 +11,27 @@ export interface DrawerInputProps
  */
 export const DrawerInput = ({ label, onInput, ...props }: DrawerInputProps) => {
   return (
-    <input
-      aria-label={label}
-      onInput={onInput}
-      style={{
-        width: "calc(100% - 6px)",
-        borderColor: "transparent",
-      }}
-      {...props}
-    />
+    <>
+      <style>
+        {`
+          .DrawerInput--input::placeholder {
+            color: var(--theme-accent-icon);
+            padding-left: 3px;
+          }
+        `}
+      </style>
+      <input
+        className="DrawerInput--input"
+        aria-label={label}
+        onInput={onInput}
+        style={{
+          width: "calc(100% - 6px)",
+          borderColor: "transparent",
+          color: "var(--theme-primary-text)",
+          marginLeft: 4,
+        }}
+        {...props}
+      />
+    </>
   );
 };

--- a/src/components/DrawerInput.tsx
+++ b/src/components/DrawerInput.tsx
@@ -9,7 +9,11 @@ export interface DrawerInputProps
 /**
  * Simple component for recreating the UI/UX of an Aha! record drawer input.
  */
-export const DrawerInput = ({ label, onInput, ...props }: DrawerInputProps) => {
+export const DrawerInput = ({
+  label,
+  onChange,
+  ...props
+}: DrawerInputProps) => {
   return (
     <>
       <style>
@@ -23,7 +27,14 @@ export const DrawerInput = ({ label, onInput, ...props }: DrawerInputProps) => {
       <input
         className="DrawerInput--input"
         aria-label={label}
-        onInput={onInput}
+        onBlur={(event: React.BlurEvent<HTMLInputElement>) =>
+          onChange(event.target.value)
+        }
+        onKeyDown={(event: React.KeyDownEvent<HTMLInputElement>) => {
+          if (event.key === "Enter") {
+            event.target.blur();
+          }
+        }}
         style={{
           width: "calc(100% - 6px)",
           borderColor: "transparent",

--- a/src/patterns/EmbeddedContentAttribute.tsx
+++ b/src/patterns/EmbeddedContentAttribute.tsx
@@ -12,6 +12,7 @@ export interface EmbeddedContentAttributeProps {
   /** Optional function that allows component to modify supplied user input before saving */
   onLinkUpdated?: LinkUpdatedCallback;
   aspectRatio?: number;
+  fieldName?: string;
 }
 
 /**
@@ -28,8 +29,8 @@ export const EmbeddedContentAttribute = ({
   placeholder,
   onLinkUpdated = (v) => v,
   aspectRatio = 4 / 3,
+  fieldName = `${product.replace(/\s+/g, "")}:link`,
 }: EmbeddedContentAttributeProps) => {
-  const fieldName = `${product.replace(/\s+/g, '')}:link`
   const src = fields[fieldName] as string;
 
   const openLink = () => {

--- a/src/patterns/EmbeddedContentAttribute.tsx
+++ b/src/patterns/EmbeddedContentAttribute.tsx
@@ -87,9 +87,10 @@ export const EmbeddedContentAttribute = ({
             </aha-menu-item>
           </aha-menu-group>
           <aha-menu-group>
-            <aha-menu-item>
+            <aha-menu-item type="danger">
               <aha-button kind="plain" onClick={removeLink}>
-                <span className="text-error">Remove</span>
+                <aha-icon icon="fa fa-trash" />
+                Remove
               </aha-button>
             </aha-menu-item>
           </aha-menu-group>

--- a/src/patterns/EmbeddedContentAttribute.tsx
+++ b/src/patterns/EmbeddedContentAttribute.tsx
@@ -38,9 +38,7 @@ export const EmbeddedContentAttribute = ({
     window.open(sanitized, "_blank", "noopener,noreferrer");
   };
 
-  const setLink = (e: React.ChangeEvent<HTMLInputElement>) => {
-    let value = e.target.value;
-
+  const setLink = (value: string) => {
     if (!value) return;
 
     Promise.resolve(value)
@@ -59,7 +57,7 @@ export const EmbeddedContentAttribute = ({
       <DrawerInput
         label={`${product} link`}
         placeholder={placeholder}
-        onInput={setLink}
+        onChange={setLink}
       />
     );
   }

--- a/src/patterns/EmbeddedContentAttribute.tsx
+++ b/src/patterns/EmbeddedContentAttribute.tsx
@@ -75,12 +75,7 @@ export const EmbeddedContentAttribute = ({
     >
       <EmbeddedContent src={src} aspectRatio={aspectRatio} />
       <aha-menu>
-        <aha-button
-          slot="control"
-          kind="secondary"
-          size="mini"
-          class="attribute__control"
-        >
+        <aha-button slot="control" kind="secondary" size="mini">
           <aha-icon icon="fa-solid fa-ellipsis"></aha-icon>
         </aha-button>
         <aha-menu-content>

--- a/src/patterns/EmbeddedContentAttribute.tsx
+++ b/src/patterns/EmbeddedContentAttribute.tsx
@@ -69,14 +69,23 @@ export const EmbeddedContentAttribute = ({
     >
       <EmbeddedContent src={src} aspectRatio={aspectRatio} />
       <aha-menu>
-        <aha-button slot="button" type="attribute" size="small">
+        <aha-button slot="control" kind="attribute" size="small">
           <aha-icon icon="fa-solid fa-ellipsis"></aha-icon>
         </aha-button>
-        <aha-menu-item onClick={openLink}>View in {product}</aha-menu-item>
-        <hr />
-        <aha-menu-item onClick={removeLink}>
-          <span className="text-error">Remove</span>
-        </aha-menu-item>
+        <aha-menu-content>
+          <aha-menu-group>
+            <aha-menu-item>
+              <a href="#" onClick={openLink}>View in {product}</a>
+            </aha-menu-item>
+          </aha-menu-group>
+          <aha-menu-group>
+            <aha-menu-item>
+              <a href="#" onClick={removeLink}>
+                <span className="text-error">Remove</span>
+              </a>
+            </aha-menu-item>
+          </aha-menu-group>
+        </aha-menu-content>
       </aha-menu>
     </div>
   )

--- a/src/patterns/EmbeddedContentAttribute.tsx
+++ b/src/patterns/EmbeddedContentAttribute.tsx
@@ -69,7 +69,7 @@ export const EmbeddedContentAttribute = ({
     >
       <EmbeddedContent src={src} aspectRatio={aspectRatio} />
       <aha-menu>
-        <aha-button slot="control" kind="attribute" size="small">
+        <aha-button slot="control" kind="secondary" size="mini" class="attribute__control">
           <aha-icon icon="fa-solid fa-ellipsis"></aha-icon>
         </aha-button>
         <aha-menu-content>

--- a/src/patterns/EmbeddedContentAttribute.tsx
+++ b/src/patterns/EmbeddedContentAttribute.tsx
@@ -75,14 +75,14 @@ export const EmbeddedContentAttribute = ({
         <aha-menu-content>
           <aha-menu-group>
             <aha-menu-item>
-              <a href="#" onClick={openLink}>View in {product}</a>
+              <aha-button kind="plain" onClick={openLink}>View in {product}</aha-button>
             </aha-menu-item>
           </aha-menu-group>
           <aha-menu-group>
             <aha-menu-item>
-              <a href="#" onClick={removeLink}>
+              <aha-button kind="plain" onClick={removeLink}>
                 <span className="text-error">Remove</span>
-              </a>
+              </aha-button>
             </aha-menu-item>
           </aha-menu-group>
         </aha-menu-content>

--- a/src/patterns/EmbeddedContentAttribute.tsx
+++ b/src/patterns/EmbeddedContentAttribute.tsx
@@ -34,8 +34,8 @@ export const EmbeddedContentAttribute = ({
 
   const openLink = () => {
     const sanitized = aha.sanitizeUrl(src);
-    window.open(sanitized, '_blank', 'noopener,noreferrer');
-  }
+    window.open(sanitized, "_blank", "noopener,noreferrer");
+  };
 
   const setLink = (e: React.ChangeEvent<HTMLInputElement>) => {
     let value = e.target.value;
@@ -65,17 +65,29 @@ export const EmbeddedContentAttribute = ({
 
   return (
     <div
-      style={{ display: 'grid', alignItems: 'start', gridTemplateColumns: '1fr auto', gridGap: 10 }}
+      style={{
+        display: "grid",
+        alignItems: "start",
+        gridTemplateColumns: "1fr auto",
+        gridGap: 10,
+      }}
     >
       <EmbeddedContent src={src} aspectRatio={aspectRatio} />
       <aha-menu>
-        <aha-button slot="control" kind="secondary" size="mini" class="attribute__control">
+        <aha-button
+          slot="control"
+          kind="secondary"
+          size="mini"
+          class="attribute__control"
+        >
           <aha-icon icon="fa-solid fa-ellipsis"></aha-icon>
         </aha-button>
         <aha-menu-content>
           <aha-menu-group>
             <aha-menu-item>
-              <aha-button kind="plain" onClick={openLink}>View in {product}</aha-button>
+              <aha-button kind="plain" onClick={openLink}>
+                View in {product}
+              </aha-button>
             </aha-menu-item>
           </aha-menu-group>
           <aha-menu-group>
@@ -88,5 +100,5 @@ export const EmbeddedContentAttribute = ({
         </aha-menu-content>
       </aha-menu>
     </div>
-  )
+  );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,10 +26,10 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
   integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
 
-prettier@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
-  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+prettier@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
+  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
 
 typescript@^4.2.3:
   version "4.5.5"


### PR DESCRIPTION
- Updates components to use latest `aha-menu` web component
- Makes some other changes to the `EmbeddedContentAttributeProps` component to make it work/look better for other extensions
- Fixes `DrawerInput` to use change/keydown events instead of `onInput`

![Screen Shot 2022-12-30 at 9 32 53 AM](https://user-images.githubusercontent.com/125077/210095616-1ab629f1-0675-4969-bc44-7193daf7a291.png)
