### PR TITLE
A-18176: [Global] Figma extension input 

### DIFF
--- a/src/components/AspectRatio.tsx
+++ b/src/components/AspectRatio.tsx
@@ -6,17 +6,7 @@ export interface AspectRatioProps {
 }
 
 export const AspectRatio = ({ aspectRatio, children }: AspectRatioProps) => (
-  <div style={{ position: 'relative', paddingTop: `${100 / aspectRatio}%` }}>
-    <div
-      style={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-      }}
-    >
-      {children}
-    </div>
+  <div style={{ position: "relative", paddingTop: `${100 / aspectRatio}%` }}>
+    <div className="AspectRatio--content">{children}</div>
   </div>
 );

--- a/src/components/AspectRatio.tsx
+++ b/src/components/AspectRatio.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import "./../index.css";
+
 export interface AspectRatioProps {
   aspectRatio: number;
   children: any;

--- a/src/components/DrawerInput.tsx
+++ b/src/components/DrawerInput.tsx
@@ -1,4 +1,4 @@
-import React, { FocusEvent } from "react";
+import React from "react";
 
 export interface DrawerInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {

--- a/src/components/DrawerInput.tsx
+++ b/src/components/DrawerInput.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import "./../index.css";
+
 export interface DrawerInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label: string;
@@ -16,14 +18,6 @@ export const DrawerInput = ({
 }: DrawerInputProps) => {
   return (
     <>
-      <style>
-        {`
-          .DrawerInput--input::placeholder {
-            color: var(--theme-accent-icon);
-            padding-left: 3px;
-          }
-        `}
-      </style>
       <input
         className="DrawerInput--input"
         aria-label={label}
@@ -39,13 +33,6 @@ export const DrawerInput = ({
             const target = event.target as HTMLInputElement;
             target.blur();
           }
-        }}
-        style={{
-          width: "calc(100% - 6px)",
-          borderColor: "transparent",
-          color: "var(--theme-primary-text)",
-          background: "var(--theme-primary-background)",
-          marginLeft: 4,
         }}
         {...props}
       />

--- a/src/components/DrawerInput.tsx
+++ b/src/components/DrawerInput.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FocusEvent } from "react";
 
 export interface DrawerInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -27,18 +27,24 @@ export const DrawerInput = ({
       <input
         className="DrawerInput--input"
         aria-label={label}
-        onBlur={(event: React.BlurEvent<HTMLInputElement>) =>
-          onChange(event.target.value)
-        }
-        onKeyDown={(event: React.KeyDownEvent<HTMLInputElement>) => {
+        onBlur={({ target }) => {
+          if (onChange) {
+            onChange({
+              target: { value: target.value },
+            } as React.ChangeEvent<HTMLInputElement>);
+          }
+        }}
+        onKeyDown={(event) => {
           if (event.key === "Enter") {
-            event.target.blur();
+            const target = event.target as HTMLInputElement;
+            target.blur();
           }
         }}
         style={{
           width: "calc(100% - 6px)",
           borderColor: "transparent",
           color: "var(--theme-primary-text)",
+          background: "var(--theme-primary-background)",
           marginLeft: 4,
         }}
         {...props}

--- a/src/components/EmbeddedContent.tsx
+++ b/src/components/EmbeddedContent.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { AspectRatio } from "./AspectRatio";
 
+import "./../index.css";
+
 export interface EmbeddedContentProps {
   src: string;
   aspectRatio?: number;

--- a/src/components/EmbeddedContent.tsx
+++ b/src/components/EmbeddedContent.tsx
@@ -20,7 +20,7 @@ export const EmbeddedContent = ({
       <aha-box>
         <p>No URL provided</p>
       </aha-box>
-    )
+    );
   }
 
   return (
@@ -31,13 +31,10 @@ export const EmbeddedContent = ({
         height="100%"
         allowTransparency
         allowFullScreen
-        style={{
-          border: "1px solid var(--theme-primary-border)",
-          clipPath: "inset(1px 1px);",
-        }}
+        className="EmbeddedContent--iframe"
       >
         Unable to load content
       </iframe>
     </AspectRatio>
-  )
-}
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,25 @@
+.AspectRatio--content {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.DrawerInput--input {
+  width: calc(100% - 6px);
+  border-color: transparent;
+  color: var(--theme-primary-text);
+  background: var(--theme-primary-background);
+  margin-left: 4px;
+}
+
+.DrawerInput--input::placeholder {
+  color: var(--theme-accent-icon);
+  padding-left: 3px;
+}
+
+.EmbeddedContent--iframe {
+  border: 1px solid var(--theme-primary-border);
+  clip-path: inset(1px 1px);
+}

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1,0 +1,9 @@
+import React from "react";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "aha-box": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}


### PR DESCRIPTION
Task here was to change the background color of the input to handle dark mode.

https://big.aha.io/features/A-18176

BEFORE:

<img width="460"  alt="Screenshot 2025-03-17 at 5 18 14 PM" src="https://github.com/user-attachments/assets/5070dc9b-444f-48b5-8b37-7466e683d746" />

I also collated the styles for the components into a stylesheet and fixed simple typescript errors where I saw them.

Not sure how to test this, or what the go is for deploying this for `aha-app`.

- Change background color to use css themed vars
- Remove unused import
- Move styles to a stylesheet