### PR TITLE
DEVELOP-2280-12: Move SendToAI component into aha-develop-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aha-app/aha-develop-react",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Common React patterns for Aha! develop",
   "main": "dist/index.js",
   "repository": "https://github.com/aha-develop/aha-develop-react",

--- a/src/components/SendToAI.tsx
+++ b/src/components/SendToAI.tsx
@@ -1,0 +1,45 @@
+import React, { ReactNode } from "react";
+
+export const SendToAI = ({
+  label,
+  button,
+  icon,
+  footer,
+}: {
+  label: string;
+  button: ReactNode;
+  alert?: ReactNode;
+  icon?: ReactNode;
+  footer?: ReactNode;
+}) => {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+      {alert}
+      <div
+        style={{
+          display: "flex",
+          paddingLeft: "7px",
+          flexDirection: "column",
+          gap: "4px",
+        }}
+      >
+        <div style={{ display: "flex", width: "100%", alignItems: "center" }}>
+          <div
+            style={{
+              display: "flex",
+              gap: "6px",
+              flex: "1 0 auto",
+              alignItems: "center",
+            }}
+          >
+            {icon} {label}
+          </div>
+          {button}
+        </div>
+        {footer ? (
+          <div style={{ color: "var(--theme-secondary-text)" }}>{footer}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Include shared SendToAI component

This component is currently in use by all our AI extensions.  Centralising here.


https://github.com/aha-develop/assign-devin/blob/e10bb41663c6fb8e21ee67e523c820f9c37263ec/src/views/SendToDevinButton.tsx#L66-L101